### PR TITLE
Fix incomplete bad creation dates and incomplete results

### DIFF
--- a/config/redspira.php
+++ b/config/redspira.php
@@ -5,5 +5,5 @@ return [
     'api_base_url' => 'http://app.respira.org.mx/ws/get-monitor-data.php',
 
     // Display request debug on console after each request
-    'debug_requests' => false,
+    'debug_requests' => true,
 ];

--- a/src/Api/Device.php
+++ b/src/Api/Device.php
@@ -2,6 +2,7 @@
 
 namespace Javleds\RedspiraApi\Api;
 
+use Carbon\Carbon;
 use DateTime;
 use DateTimeZone;
 use Exception;
@@ -50,19 +51,19 @@ class Device extends AbstractApi implements DeviceInterface
      */
     public function getRegistriesForLastHours(string $deviceId, string $parameterId, int $hours, int $timeOffset = -7)
     {
-        $endInterval = new DateTime();
+        $endInterval = Carbon::now($timeOffset);
 
-        $differenceInHours = sprintf('- %d hour', $hours);
         $startInterval = clone $endInterval;
-        $startInterval->modify($differenceInHours);
+        $startInterval->subHours($hours);
 
 
         $parameters = new DeviceParameters(
             $deviceId,
             $parameterId,
-            $startInterval,
-            $endInterval,
-            DeviceParameters::HOUR_INTERVAL
+            $startInterval->toDateTime(),
+            $endInterval->toDateTime(),
+            DeviceParameters::HOUR_INTERVAL,
+            $timeOffset
         );
 
         return $this->getRegistries($parameters);

--- a/src/DataParameters/DeviceParameters.php
+++ b/src/DataParameters/DeviceParameters.php
@@ -185,6 +185,8 @@ class DeviceParameters implements ApiParameter
             $this->timeOffset
         );
 
+        $startInterval->subHours(1);
+
         $endInterval = Carbon::createFromFormat(
             self::ENDPOINT_DATE_FORMAT,
             $this->endDate->format(self::ENDPOINT_DATE_FORMAT),

--- a/tests/Feature/Api/DeviceEndpointTest.php
+++ b/tests/Feature/Api/DeviceEndpointTest.php
@@ -51,12 +51,16 @@ class DeviceEndpointTest extends BaseTestCaste
      */
     public function testDeviceGetRegistriesByHours()
     {
+        $hours = 12;
         $registries = RedspiraApi::device()->getRegistriesForLastHours(
             self::DEVICE_ID,
             DeviceParameters::PM10_PARAMETER,
-            12
+            $hours
         );
 
+        $size = $registries->count();
+
         $this->assertNotEmpty($registries);
+        $this->assertSame($hours, $size);
     }
 }


### PR DESCRIPTION
Now the device->getRegistriesForLastHours returns as much registries as specified $hours